### PR TITLE
Add dictate to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [AiLama](https://github.com/zeyoyt/ailama)                          | Open Source :heavy_check_mark: <br /> Discord User App :heavy_check_mark: <br /> Multi Function :heavy_check_mark: <br /> | Gradle+Java <br /> Docker |
 | [Cloud Seeder](https://github.com/ipv6rslimited/cloudseeder)        | One-click deployment and maintenance suite for Ollama and OpenWebUI with external IP                                      | Multi-platform downloads  | 
 | [vnc-m](https://github.com/jake83741/vnc-lm)                        | A Discord bot with support for model downloads, parameter adjustments, conversation branching, and prompt refinement.                   | Docker <br> NPM  |
+| [dictate](https://github.com/lewiswigmore/macOS-dictate)            | Privacy-first voice typing for macOS. Local Whisper ASR with optional Ollama cleanup. Open Source :heavy_check_mark: <br /> Menu-bar App :heavy_check_mark: | macOS source install |
 
 ## Model Evaluation and Testing Tools
 


### PR DESCRIPTION
[dictate](https://github.com/lewiswigmore/macOS-dictate) is a privacy-first voice typing app for macOS. Speech recognition runs on-device with Whisper; Ollama is one of two opt-in cleanup backends (the other is OpenRouter).

- Local Whisper ASR.
- Ollama auto-picks the best installed model (>= 3B) with health-check fallback.
- Per-app vocab presets, voice commands, secret redaction before any external call.
- Loopback-only WebUI for history, dashboard and settings.
- MIT licensed.

Released: v0.1.0
Source: <https://github.com/lewiswigmore/macOS-dictate>

Affiliation: I am the maintainer.