### PR TITLE
Add pyimgtag to Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [osync](https://github.com/mann1x/osync/)        | Copy local Ollama models to any accessible remote Ollama instance, C# .NET 8 <br /> Open Source :heavy_check_mark: <br /> Windows :heavy_check_mark: <br /> macOS :heavy_check_mark: <br /> Linux x64/arm64 :heavy_check_mark: | Multi-platform downloads  |
 | [ollamarsync](https://github.com/mann1x/ollamarsync/)        | Copy local Ollama models to any accessible remote Ollama instance <br /> Open Source :heavy_check_mark:                          | Multi-platform Python     |
 | [shell-ask](https://github.com/egoist/shell-ask)        | Ask LLM directly from your terminal <br /> Open Source :heavy_check_mark:  <br /> Multi Function :heavy_check_mark:                   | Multi-platform downloads  |
-| [pyimgtag](https://github.com/kurok/pyimgtag) | Tag a photo library with a local Ollama vision model (Gemma) — searchable tags, scene category, and EXIF-GPS location; then query, score, and clean up from the CLI <br /> Open Source :heavy_check_mark: | Multi-platform Python |
+| [pyimgtag](https://github.com/kurok/pyimgtag) | Tag a photo library with a local vision model (Gemma) — searchable tags, scene category, and EXIF-GPS location; then query, score, and clean up from the CLI <br /> Open Source :heavy_check_mark: | Multi-platform Python |
 
 ## Databases
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [osync](https://github.com/mann1x/osync/)        | Copy local Ollama models to any accessible remote Ollama instance, C# .NET 8 <br /> Open Source :heavy_check_mark: <br /> Windows :heavy_check_mark: <br /> macOS :heavy_check_mark: <br /> Linux x64/arm64 :heavy_check_mark: | Multi-platform downloads  |
 | [ollamarsync](https://github.com/mann1x/ollamarsync/)        | Copy local Ollama models to any accessible remote Ollama instance <br /> Open Source :heavy_check_mark:                          | Multi-platform Python     |
 | [shell-ask](https://github.com/egoist/shell-ask)        | Ask LLM directly from your terminal <br /> Open Source :heavy_check_mark:  <br /> Multi Function :heavy_check_mark:                   | Multi-platform downloads  |
+| [pyimgtag](https://github.com/kurok/pyimgtag) | Tag a photo library with a local Ollama vision model (Gemma) — searchable tags, scene category, and EXIF-GPS location; then query, score, and clean up from the CLI <br /> Open Source :heavy_check_mark: | Multi-platform Python |
 
 ## Databases
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ inspired by [Awesome Python](https://github.com/vinta/awesome-python)
 | [ollamamodelupdater](https://github.com/technovangelist/ollamamodelupdater) | Update ollama models to the latest version in the Library                                                                                                                                              | Multi-platform downloads |
 | [ollamarsync](https://github.com/mann1x/ollamarsync/)                       | Copy local Ollama models to any accessible remote Ollama instance, Open Source :heavy_check_mark:                                                                                                      | Multi-platform Python    |
 | [osync](https://github.com/mann1x/osync/)                                   | Copy local Ollama models to any accessible remote Ollama instance, C# .NET 8, Open Source :heavy_check_mark:, Windows :heavy_check_mark:, macOS :heavy_check_mark:, Linux x64/arm64 :heavy_check_mark: | Multi-platform downloads |
+| [pyimgtag](https://github.com/kurok/pyimgtag)                               | Tag a photo library with a local vision model (Gemma) — searchable tags, scene category, and EXIF-GPS location; then query, score, and clean up from the CLI, Open Source :heavy_check_mark: | Multi-platform Python    |
 
 ## Model Evaluation and Testing Tools
 


### PR DESCRIPTION
Adds [pyimgtag](https://github.com/kurok/pyimgtag) to the **Terminal** section.

pyimgtag is a command-line photo tagger that uses a local Ollama vision model (Gemma by default) to write 1–5 searchable tags, a scene category, and EXIF-GPS-based location for every image — fully on-device. It also lets you query, filter, score, and clean up the library from the CLI. MIT, [on PyPI](https://pypi.org/project/pyimgtag/), runs on macOS/Linux/Windows. Added as a table row matching the section's existing format.